### PR TITLE
Added option to specify region parameter when add/remove users

### DIFF
--- a/src/cmd/addUser.js
+++ b/src/cmd/addUser.js
@@ -9,20 +9,22 @@ exports.run = async (bot, msg, params) => {
     }
     let username = params[0].toLowerCase();
 
-    msg.channel.send('Checking for ' + username + '\'s PUBG Id ... give me a second')
+    let serverDefaults = await sql.getServerDefaults(msg.guild.id);
+    let region = cs.getParamValue('region=', params, serverDefaults.default_region);
+
+    msg.channel.send(`Checking for ${username}'s PUBG Id ... give me a second`)
         .then(async (message) => {
-            let pubgId = await scrape.getCharacterID(username);
+            let pubgId = await scrape.getCharacterID(username, region);
         
             if (pubgId && pubgId !== '') {
                 let registered = await sql.registerUserToServer(pubgId, message.guild.id);
                 if(registered) {
-                    message.edit('Added ' + username);
+                    message.edit(`Added ${username}`);
                 } else {
-                    message.edit('Could not add ' + username);
+                    message.edit(`Could not add ${username}`);
                 }
-                
             } else {
-                message.edit('Invalid username: ' + username);
+                message.edit(`Could not find ${username} on the ${region} region. Double check the username and region.`);
             }
         });
 };
@@ -37,8 +39,9 @@ exports.conf = {
 let help = exports.help = {
     name: 'addUser',
     description: 'Adds a user to the server\'s registery.',
-    usage: '<prefix>addUser <pubg username>',
+    usage: '<prefix>addUser <pubg username> [region=(na | as | kr/jp | kakao | sa | eu | oc | sea)]',
     examples: [
-        '!pubg-addUser john'
+        '!pubg-addUser john',
+        '!pubg-addUser john region=eu'
     ]
 };

--- a/src/cmd/rank.js
+++ b/src/cmd/rank.js
@@ -28,11 +28,11 @@ exports.run = async (bot, msg, params) => {
         return;
     }
     
-    checkingParametersMsg.edit('Getting data for ' + username)
+    checkingParametersMsg.edit(`Getting data for ${username}`)
         .then(async (message) => {
-            let id = await scrape.getCharacterID(username);
+            let id = await scrape.getCharacterID(username, region);
             if(!id) {
-                message.edit('Invalid username: ' + username);
+                message.edit(`Could not find ${username} on the ${region} region. Double check the username and region.`);
                 return;
             }
             let soloData = await scrape.getPUBGCharacterData(id, username, season, region, 1, mode);

--- a/src/cmd/removeUser.js
+++ b/src/cmd/removeUser.js
@@ -8,20 +8,22 @@ exports.run = async (bot, msg, params) => {
         return;
     }
     let username = params[0].toLowerCase();
+    let serverDefaults = await sql.getServerDefaults(msg.guild.id);
+    let region = cs.getParamValue('region=', params, serverDefaults.default_region);
 
-    msg.channel.send('Removing ' + username + ' from server registry')
+    msg.channel.send(`Removing ${username} from server registry`)
         .then(async (message) => {
-            let pubgId = await scrape.getCharacterID(username);
+            let pubgId = await scrape.getCharacterID(username, region);
             if(!pubgId) {
-                message.edit('Invalid username: ' + username);
+                message.edit(`Could not find ${username} on the ${region} region. Double check the username and region.`);
                 return;
             }
 
             let unregistered = await sql.unRegisterUserToServer(pubgId, message.guild.id);
             if(unregistered) {
-                message.edit('Removed ' + username + ' from server registry');
+                message.edit(`Removed ${username} from server registry`);
             } else {
-                message.edit(username + ' did not exist on server registery');
+                message.edit(`${username} does not exist on server registery`);
             }
             
         });
@@ -37,8 +39,9 @@ exports.conf = {
 let help = exports.help = {
     name: 'removeUser',
     description: 'Removes a user from the server\'s registery.',
-    usage: '<prefix>removeUser <username>',
+    usage: '<prefix>removeUser <username> [region=(na | as | kr/jp | kakao | sa | eu | oc | sea)]',
     examples: [
         '!pubg-removeUser john',
+        '!pubg-removeUser john region=na'
     ]
 };

--- a/src/cmd/top.js
+++ b/src/cmd/top.js
@@ -42,7 +42,7 @@ exports.run = async (bot, msg, params) => {
                     msg.edit(`Grabbing data for players ${i+1} - ${max}`);
                 }            
                 
-                let id = await scrape.getCharacterID(player.username);
+                let id = await scrape.getCharacterID(player.username, region);
                 let characterInfo = await scrape.getPUBGCharacterData(id, player.username, season, region, +squadSize, mode);
 
                 // Check if character info exists for this (it wont if a user hasn't played yet)

--- a/src/services/pubg.service.js
+++ b/src/services/pubg.service.js
@@ -17,9 +17,9 @@ module.exports = {
     isValidSquadSize
 };
 
-// Webscraping URL --> pubgBaseRL + <username> + pubgNAServer
+// Webscraping URL --> pubgBaseRL + <username> + pubgServer
 const pubgBaseURL = 'https://pubg.op.gg/user/';
-const pubgNAServer = '?server=na';
+const pubgServer = '?server=';
 // Direct API URL --> apiURL + <id> + apiOptions
 const apiURL = 'https://pubg.op.gg/api/users/'; 
 const apiOptions = '/ranked-stats';
@@ -28,7 +28,7 @@ const apiOptions = '/ranked-stats';
  * Returns a pubg character id
  * @param {string} username 
  */
-async function getCharacterID(username) {
+async function getCharacterID(username, region) {
     username = username.toLowerCase();
 
     return sql.getPlayer(username)
@@ -36,7 +36,7 @@ async function getCharacterID(username) {
             if(player && player.pubg_id && player.pubg_id !== '') {
                 return player.pubg_id;
             } else {
-                return webScrapeForId(username);
+                return webScrapeForId(username, region);
             }
         });
 }
@@ -45,9 +45,9 @@ async function getCharacterID(username) {
  * Using curl this scrapes pubg.op.gg for pubg character id.
  * @param {string} username: pubg username 
  */
-function webScrapeForId(username) {
-    logger.info('\tWebscraping for ' + username);
-    let url = pubgBaseURL + username + pubgNAServer;
+function webScrapeForId(username, region) {
+    logger.info(`\tWebscraping for ${username} on the ${region} region`);
+    let url = pubgBaseURL + username + pubgServer + region;
     return new Promise(function(resolve, reject){ 
         curl.request(url, async (err, stdout) => {
             if(err) { reject(err); }


### PR DESCRIPTION
This fixes the issue that a user was running into where they never played on the default region (`na`) I used to grab pubg id's. 

If the user NEVER played on `na` then `pubg.op.gg` displays an error page which doesn't let us grab their id. Allowing users the options to specify a region fixes this.